### PR TITLE
Remove default key during project creation

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -121,7 +121,7 @@ func resourceSentryProjectCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.Get("remove_default_key").(bool) {
-		err = removeDefaultKey(meta, org, proj.Slug)
+		err = removeDefaultKey(client, org, proj.Slug)
 		if err != nil {
 			return err
 		}
@@ -231,9 +231,7 @@ func resourceSentryProjectImporter(d *schema.ResourceData, meta interface{}) ([]
 	return []*schema.ResourceData{d}, nil
 }
 
-func removeDefaultKey(meta interface{}, org, projSlug string) error {
-	client := meta.(*sentryclient.Client)
-
+func removeDefaultKey(client *sentryclient.Client, org, projSlug string) error {
 	keys, _, err := client.ProjectKeys.List(org, projSlug)
 	if err != nil {
 		return err

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -30,6 +30,12 @@ func resourceSentryProject() *schema.Resource {
 				Required:    true,
 				Description: "The slug of the team to create the project for",
 			},
+			"remove_default_key": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to remove the default key",
+				Default:     false,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -114,7 +120,15 @@ func resourceSentryProjectCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	if d.Get("remove_default_key").(bool) {
+		err = removeDefaultKey(meta, org, proj.Slug)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(proj.Slug)
+
 	return resourceSentryProjectRead(d, meta)
 }
 
@@ -215,4 +229,23 @@ func resourceSentryProjectImporter(d *schema.ResourceData, meta interface{}) ([]
 	d.SetId(parts[1])
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func removeDefaultKey(meta interface{}, org, projSlug string) error {
+	client := meta.(*sentryclient.Client)
+
+	keys, _, err := client.ProjectKeys.List(org, projSlug)
+	if err != nil {
+		return err
+	}
+	var defaultKeyId string
+	for _, key := range keys {
+		if key.Name == "Default" {
+			defaultKeyId = key.ID
+			break
+		}
+	}
+
+	client.ProjectKeys.Delete(org, projSlug, defaultKeyId)
+	return nil
 }


### PR DESCRIPTION
In order to sync the project keys, the default key need to be removed.
A new key will be created via terraform so that it's auto synced.
long discussion: https://canva.slack.com/archives/CB5R5LJ10/p1573437132005100?thread_ts=1573437132.005100