### PR TITLE
Add Sentry integration parameters to rule conditions

### DIFF
--- a/sentryclient/rules.go
+++ b/sentryclient/rules.go
@@ -23,8 +23,11 @@ type Rule struct {
 // RuleCondition represents the conditions for each rule.
 // https://github.com/getsentry/sentry/blob/9.0.0/src/sentry/api/serializers/models/rule.py
 type RuleCondition struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Attribute string `json:"attribute,omitempty"`
+	Match     string `json:"match,omitempty"`
+	Value     string `json:"value,omitempty"`
 }
 
 // RuleAction represents the actions will be taken for each rule based on its conditions.

--- a/sentryclient/rules.go
+++ b/sentryclient/rules.go
@@ -25,9 +25,6 @@ type Rule struct {
 type RuleCondition struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
-	Attribute string `json:"attribute,omitempty"`
-	Match     string `json:"match,omitempty"`
-	Value     string `json:"value,omitempty"`
 }
 
 // RuleAction represents the actions will be taken for each rule based on its conditions.

--- a/sentryclient/rules.go
+++ b/sentryclient/rules.go
@@ -78,6 +78,8 @@ type CreateRuleActionParams struct {
 	Tags      string `json:"tags"`
 	Channel   string `json:"channel"`
 	Workspace string `json:"workspace"`
+	Action    string `json:"action,omitempty"`
+	Service   string `json:"service,omitempty"`
 }
 
 // CreateRuleConditionParams models the conditions when creating the action for the rule.
@@ -86,6 +88,8 @@ type CreateRuleConditionParams struct {
 	Attribute string `json:"attribute,omitempty"`
 	Match     string `json:"match,omitempty"`
 	Value     string `json:"value,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Interval  string `json:"interval,omitempty"`
 }
 
 // Create a new alert rule bound to a project.

--- a/sentryclient/rules.go
+++ b/sentryclient/rules.go
@@ -79,7 +79,10 @@ type CreateRuleActionParams struct {
 
 // CreateRuleConditionParams models the conditions when creating the action for the rule.
 type CreateRuleConditionParams struct {
-	ID string `json:"id"`
+	ID        string `json:"id"`
+	Attribute string `json:"attribute,omitempty"`
+	Match     string `json:"match,omitempty"`
+	Value     string `json:"value,omitempty"`
 }
 
 // Create a new alert rule bound to a project.


### PR DESCRIPTION
Rule creation doesn't work for more complicated conditions and actions (Sentry notification action and OpsGenie action.)
Turns out the provider only sends the `id` part of the `conditions` param.

This should fix that by also sending additional fields.
