### PR TITLE
Allow mapping many teams to one project

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -155,6 +155,8 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	team := d.Get("team").(string)
 	var teams []interface{}
 	if team == "" {
+		// Since `Set.List()` produces deterministic ordering, `teams[0]` should always
+		// resolve to the same value given the same `teams`.
 		teams = d.Get("teams").(*schema.Set).List()
 		team = teams[0].(string)
 	}

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -283,28 +283,28 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(proj.Slug)
 
-	setTeams := func(o map[string]bool, n map[string]bool) diag.Diagnostics {
+	setTeams := func(oldTeams map[string]bool, newTeams map[string]bool) diag.Diagnostics {
 		tflog.Debug(ctx, "Adding teams to project", map[string]interface{}{
-			"org":     org,
-			"project": project,
-			"teams":   n,
+			"org":        org,
+			"project":    project,
+			"teamsToAdd": newTeams,
 		})
-		for team := range n {
-			_, _, err = client.Projects.AddTeam(ctx, org, project, team)
+		for newTeam := range newTeams {
+			_, _, err = client.Projects.AddTeam(ctx, org, project, newTeam)
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
-		if o != nil {
+		if oldTeams != nil {
 			tflog.Debug(ctx, "Removing teams from project", map[string]interface{}{
-				"org":     org,
-				"project": project,
-				"teams":   o,
+				"org":           org,
+				"project":       project,
+				"teamsToRemove": oldTeams,
 			})
 
-			for team := range o {
-				resp, err := client.Projects.RemoveTeam(ctx, org, project, team)
+			for oldTeam := range oldTeams {
+				resp, err := client.Projects.RemoveTeam(ctx, org, project, oldTeam)
 				if err != nil {
 					if resp.Response.StatusCode != http.StatusNotFound {
 						return diag.FromErr(err)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -130,7 +130,7 @@ func resourceSentryProject() *schema.Resource {
 				Default:     false,
 			},
 			"allowed_domains": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "The domains allowed to be collected",
 				Optional:    true,

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -31,9 +31,19 @@ func resourceSentryProject() *schema.Resource {
 				Required:    true,
 			},
 			"team": {
-				Description: "The slug of the team to create the project for.",
+				Description: "The slug of the team to create the project for. One of 'team' or 'teams' must be set.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Deprecated:  "To be replaced by 'teams' in a future release.",
+				Optional:    true,
+			},
+			"teams": {
+				Description: "The slugs of the teams to create the project for. One of 'team' or 'teams' must be set.",
+				Type:        schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				ExactlyOneOf: []string{"team"},
+				Optional:     true,
 			},
 			"name": {
 				Description: "The name for the project.",
@@ -143,14 +153,20 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	org := d.Get("organization").(string)
 	team := d.Get("team").(string)
+	var teams []interface{}
+	if team == "" {
+		teams = d.Get("teams").(*schema.Set).List()
+		team = teams[0].(string)
+	}
 	params := &sentry.CreateProjectParams{
 		Name: d.Get("name").(string),
 		Slug: d.Get("slug").(string),
 	}
 
 	tflog.Debug(ctx, "Creating Sentry project", map[string]interface{}{
-		"teamName": team,
-		"org":      org,
+		"team":  team,
+		"teams": teams,
+		"org":   org,
 	})
 	proj, _, err := client.Projects.Create(ctx, org, team, params)
 	if err != nil {
@@ -187,12 +203,31 @@ func resourceSentryProjectRead(ctx context.Context, d *schema.ResourceData, meta
 		"org":         org,
 	})
 
+	setTeams := func() error {
+		if len(proj.Teams) <= 1 || proj.Teams == nil {
+			return multierror.Append(
+				d.Set("team", proj.Team.Slug),
+				d.Set("teams", nil),
+			)
+		}
+
+		teams := make([]string, len(proj.Teams))
+		for i, team := range proj.Teams {
+			teams[i] = *team.Slug
+		}
+
+		return multierror.Append(
+			d.Set("team", nil),
+			d.Set("teams", teams),
+		)
+	}
+
 	d.SetId(proj.Slug)
 	retErr := multierror.Append(
 		d.Set("organization", proj.Organization.Slug),
-		d.Set("team", proj.Team.Slug),
 		d.Set("name", proj.Name),
 		d.Set("slug", proj.Slug),
+		setTeams(),
 		d.Set("platform", proj.Platform),
 		d.Set("internal_id", proj.ID),
 		d.Set("is_public", proj.IsPublic),
@@ -248,32 +283,73 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(proj.Slug)
 
-	if d.HasChange("team") {
-		o, n := d.GetChange("team")
-
-		tflog.Debug(ctx, "Adding team to project", map[string]interface{}{
+	setTeams := func(o map[string]bool, n map[string]bool) diag.Diagnostics {
+		tflog.Debug(ctx, "Adding teams to project", map[string]interface{}{
 			"org":     org,
 			"project": project,
-			"team":    n,
+			"teams":   n,
 		})
-		_, _, err = client.Projects.AddTeam(ctx, org, project, n.(string))
-		if err != nil {
-			return diag.FromErr(err)
+		for team := range n {
+			_, _, err = client.Projects.AddTeam(ctx, org, project, team)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 
-		if o := o.(string); o != "" {
-			tflog.Debug(ctx, "Removing team from project", map[string]interface{}{
+		if o != nil {
+			tflog.Debug(ctx, "Removing teams from project", map[string]interface{}{
 				"org":     org,
 				"project": project,
-				"team":    o,
+				"teams":   o,
 			})
-			resp, err := client.Projects.RemoveTeam(ctx, org, project, o)
-			if err != nil {
-				if resp.Response.StatusCode != http.StatusNotFound {
-					return diag.FromErr(err)
+
+			for team := range o {
+				resp, err := client.Projects.RemoveTeam(ctx, org, project, team)
+				if err != nil {
+					if resp.Response.StatusCode != http.StatusNotFound {
+						return diag.FromErr(err)
+					}
 				}
 			}
 		}
+		return nil
+	}
+
+	oldTeams := map[string]bool{}
+	newTeams := map[string]bool{}
+	if d.HasChange("team") {
+		oldTeam, newTeam := d.GetChange("team")
+		if oldTeam.(string) != "" {
+			oldTeams[oldTeam.(string)] = true
+		}
+		if newTeam.(string) != "" {
+			newTeams[newTeam.(string)] = true
+		}
+	}
+
+	if d.HasChange("teams") {
+		o, n := d.GetChange("teams")
+		for _, oldTeam := range o.(*schema.Set).List() {
+			if oldTeam.(string) != "" {
+				oldTeams[oldTeam.(string)] = true
+			}
+		}
+		for _, newTeam := range n.(*schema.Set).List() {
+			if newTeam.(string) != "" {
+				newTeams[newTeam.(string)] = true
+			}
+		}
+	}
+
+	for newTeam := range newTeams {
+		if oldTeams[newTeam] {
+			delete(oldTeams, newTeam)
+		}
+	}
+
+	diagnostics := setTeams(oldTeams, newTeams)
+	if diagnostics != nil {
+		return diagnostics
 	}
 
 	return resourceSentryProjectRead(ctx, d, meta)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -296,22 +296,21 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 
-		if oldTeams != nil {
-			tflog.Debug(ctx, "Removing teams from project", map[string]interface{}{
-				"org":           org,
-				"project":       project,
-				"teamsToRemove": oldTeams,
-			})
+		tflog.Debug(ctx, "Removing teams from project", map[string]interface{}{
+			"org":           org,
+			"project":       project,
+			"teamsToRemove": oldTeams,
+		})
 
-			for oldTeam := range oldTeams {
-				resp, err := client.Projects.RemoveTeam(ctx, org, project, oldTeam)
-				if err != nil {
-					if resp.Response.StatusCode != http.StatusNotFound {
-						return diag.FromErr(err)
-					}
+		for oldTeam := range oldTeams {
+			resp, err := client.Projects.RemoveTeam(ctx, org, project, oldTeam)
+			if err != nil {
+				if resp.Response.StatusCode != http.StatusNotFound {
+					return diag.FromErr(err)
 				}
 			}
 		}
+
 		return nil
 	}
 

--- a/sentry/resource_sentry_project_test.go
+++ b/sentry/resource_sentry_project_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -93,6 +94,64 @@ func TestAccSentryProject_changeTeam(t *testing.T) {
 			{
 				Config: testAccSentryProjectConfig_changeTeam(teamName1, teamName2, projectName, "test_2"),
 				Check:  check(teamName2, projectName),
+			},
+		},
+	})
+}
+
+func TestAccSentryProject_teams(t *testing.T) {
+	teamNamePrefix := "tf-team-"
+	teams := []string{
+		acctest.RandomWithPrefix(teamNamePrefix + "1"),
+		acctest.RandomWithPrefix(teamNamePrefix + "2"),
+		acctest.RandomWithPrefix(teamNamePrefix + "3"),
+	}
+	projectName := acctest.RandomWithPrefix("tf-project")
+	rn := "sentry_project." + projectName
+
+	check := func(projectName string, team string, teams []string) resource.TestCheckFunc {
+		var projectID string
+
+		testChecks := []resource.TestCheckFunc{
+			testAccCheckSentryProjectExists(rn, &projectID),
+			resource.TestCheckResourceAttr(rn, "organization", testOrganization),
+			resource.TestCheckResourceAttr(rn, "name", projectName),
+			resource.TestCheckResourceAttrSet(rn, "slug"),
+			resource.TestCheckResourceAttr(rn, "platform", "go"),
+			resource.TestCheckResourceAttrSet(rn, "internal_id"),
+			resource.TestCheckResourceAttrPtr(rn, "internal_id", &projectID),
+			resource.TestCheckResourceAttrPair(rn, "project_id", rn, "internal_id"),
+		}
+
+		if team != "" {
+			testChecks = append(testChecks, resource.TestCheckResourceAttr(rn, "team", team))
+		}
+
+		for _, team := range teams {
+			testChecks = append(testChecks, resource.TestCheckTypeSetElemAttr(rn, "teams.*", team))
+		}
+
+		return resource.ComposeTestCheckFunc(testChecks...)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSentryProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryProjectConfig_teams(projectName, teams[0], []string{}),
+				Check:  check(projectName, teams[0], []string{}),
+			},
+			{
+				Config: testAccSentryProjectConfig_teams(projectName, "", teams),
+				Check:  check(projectName, "", teams),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateIdFunc: testAccSentryProjectImportStateIdFunc(rn),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -193,4 +252,48 @@ resource "sentry_project" "test" {
 	allowed_domains = ["www.test2.com", "www.test.com", "www.yourapp.com"]
 }
 	`, teamName1, teamName2, projectName, teamResourceName)
+}
+
+func testAccSentryProjectConfig_teams(projectName string, team string, teams []string) string {
+
+	config := testAccSentryOrganizationDataSourceConfig
+	teamSlugs := make([]string, len(teams))
+
+	if team != "" {
+		config += testAccSentryTeam(team)
+		return config + fmt.Sprintf(`
+	resource "sentry_project" "%[1]s"{
+		organization  = sentry_team.%[2]s.organization
+		team         = "%[2]s"
+		name          = "%[1]s"
+		platform      = "go"
+	}
+		`, projectName, team)
+	}
+
+	for i, team := range teams {
+		config += testAccSentryTeam(team)
+		teamSlugs[i] = fmt.Sprintf("sentry_team.%[1]s.slug", team)
+	}
+
+	projectTeams := "[" + strings.Join(teamSlugs, ", ") + "]"
+
+	return config + fmt.Sprintf(`
+	resource "sentry_project" "%[1]s"{
+		organization  = sentry_team.%[2]s.organization
+		teams         = %[3]s
+		name          = "%[1]s"
+		platform      = "go"
+	}
+		`, projectName, teams[0], projectTeams)
+}
+
+func testAccSentryTeam(teamName string) string {
+	return fmt.Sprintf(`
+resource "sentry_team" "%[1]s" {
+	organization = data.sentry_organization.test.id
+	name         = "%[1]s"
+	slug         = "%[1]s"
+}
+	`, teamName)
 }

--- a/sentry/resource_sentry_project_test.go
+++ b/sentry/resource_sentry_project_test.go
@@ -152,6 +152,9 @@ func TestAccSentryProject_teams(t *testing.T) {
 				ImportState:       true,
 				ImportStateIdFunc: testAccSentryProjectImportStateIdFunc(rn),
 				ImportStateVerify: true,
+				// TODO: Until we update go-sentry to include these attributes in its project.Get function,
+				// we will ignore them for now.
+				ImportStateVerifyIgnore: []string{"allowed_domains", "remove_default_key", "remove_default_rule"},
 			},
 		},
 	})


### PR DESCRIPTION
# Intent

To introduce a new attribute to the `project` resource called `teams` which allows us to map many teams to a single project. Previously, we could only attached a single team to a project via the `team` attribute.

Due to Sentry's[ asynchronous handling](https://docs.sentry.io/api/teams/delete-a-team/) of team changes, these changes were found to be difficult to test via acceptance testing. Only a couple basic tests were added. For an extensive run through, please see this [video](https://www.canva.com/design/DAFGFB6OBpA/LjwlWUysSIYacHNkt1qcAg/watch?utm_content=DAFGFB6OBpA&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton). (The API token in the video has been revoked since its recording :P)

# Example

```hcl
resource "sentry_team" "team1" {
  organization = "tajpereira"
  name         = "team1"
}

resource "sentry_team" "team2" {
  organization = "tajpereira"
  name         = "team2"
}

resource "sentry_project" "project1" {
  organization = sentry_team.team1.organization
  teams         = [sentry_team.team1.id, sentry_team.team2.id] // NEW CHANGES
  name         = "project1"
}

```

