### PR TITLE
fix: require the auth token when running the Sentry provider

### DIFF
--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -21,7 +21,7 @@ func NewProvider(version string) func() *schema.Provider {
 				"token": {
 					Description: "The authentication token used to connect to Sentry. The value can be sourced from " + "the `SENTRY_AUTH_TOKEN` environment variable.",
 					Type:        schema.TypeString,
-					Optional:    true,
+					Required:    true,
 					DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SENTRY_AUTH_TOKEN", "SENTRY_TOKEN"}, nil),
 					Sensitive:   true,
 				},


### PR DESCRIPTION
# Intent

Without these changes, the provider runs and hits a `SENTRY_AUTH_TOKEN` not found exception (unless the associated environment variable is set). 

These changes also assist developers who do not know they need to set the `SENTRY_TOKEN` environment variable when running these changes in `Canva/infrastructure`.