### PR TITLE
Fix: Set `allowed_domains` when creating or updating a project [ODC-887]

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -238,6 +238,7 @@ func resourceSentryProjectRead(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("status", proj.Status),
 		d.Set("digests_min_delay", proj.DigestsMinDelay),
 		d.Set("digests_max_delay", proj.DigestsMaxDelay),
+		d.Set("allowed_domains", proj.AllowedDomains),
 		d.Set("resolve_age", proj.ResolveAge),
 		d.Set("project_id", proj.ID), // Deprecated
 	)
@@ -272,6 +273,15 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if v, ok := d.GetOk("resolve_age"); ok {
 		params.ResolveAge = sentry.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("allowed_domains"); ok {
+		allowed_domains_set := v.(*schema.Set)
+		allowed_domains := make([]string, allowed_domains_set.Len())
+		for i, domain := range allowed_domains_set.List() {
+			allowed_domains[i] = domain.(string)
+		}
+		params.AllowedDomains = allowed_domains
 	}
 
 	tflog.Debug(ctx, "Updating project", map[string]interface{}{

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -276,12 +276,12 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if v, ok := d.GetOk("allowed_domains"); ok {
-		allowed_domains_set := v.(*schema.Set)
-		allowed_domains := make([]string, allowed_domains_set.Len())
-		for i, domain := range allowed_domains_set.List() {
-			allowed_domains[i] = domain.(string)
+		allowedDomainsSet := v.(*schema.Set)
+		allowedDomains := make([]string, allowedDomainsSet.Len())
+		for i, domain := range allowedDomainsSet.List() {
+			allowedDomains[i] = domain.(string)
 		}
-		params.AllowedDomains = allowed_domains
+		params.AllowedDomains = allowedDomains
 	}
 
 	tflog.Debug(ctx, "Updating project", map[string]interface{}{

--- a/sentry/resource_sentry_project_test.go
+++ b/sentry/resource_sentry_project_test.go
@@ -54,7 +54,7 @@ func TestAccSentryProject_basic(t *testing.T) {
 				ImportStateVerify: true,
 				// TODO: Until we update go-sentry to include these attributes in its project.Get function,
 				// we will ignore them for now.
-				ImportStateVerifyIgnore: []string{"allowed_domains", "remove_default_key", "remove_default_rule"},
+				ImportStateVerifyIgnore: []string{"remove_default_key", "remove_default_rule"},
 			},
 		},
 	})
@@ -154,7 +154,7 @@ func TestAccSentryProject_teams(t *testing.T) {
 				ImportStateVerify: true,
 				// TODO: Until we update go-sentry to include these attributes in its project.Get function,
 				// we will ignore them for now.
-				ImportStateVerifyIgnore: []string{"allowed_domains", "remove_default_key", "remove_default_rule"},
+				ImportStateVerifyIgnore: []string{"remove_default_key", "remove_default_rule"},
 			},
 		},
 	})


### PR DESCRIPTION
# Intent

The `allowed_domains` input key became broken after, I presume, the update to the upstream provider. This fixes that.