### PR TITLE
[ODC-905] Fix remove default rule and key

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -160,6 +160,7 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		teams = d.Get("teams").(*schema.Set).List()
 		team = teams[0].(string)
 	}
+
 	params := &sentry.CreateProjectParams{
 		Name: d.Get("name").(string),
 		Slug: d.Get("slug").(string),
@@ -182,6 +183,7 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	})
 
 	d.SetId(proj.Slug)
+	d.Set("slug", proj.Slug)
 	return resourceSentryProjectUpdate(ctx, d, meta)
 }
 

--- a/sentry/resource_sentry_project_test.go
+++ b/sentry/resource_sentry_project_test.go
@@ -70,6 +70,42 @@ func TestAccSentryProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccSentryProject_removeDefaultKeyOnCreate(t *testing.T) {
+	teamName := acctest.RandomWithPrefix("tf-team")
+	projectName := acctest.RandomWithPrefix("tf-project")
+	rn := "sentry_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSentryProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryProjectConfigComplex(teamName, projectName, true, false),
+				Check:  testAccSentryKeyRemoved(rn),
+			},
+		},
+	})
+}
+
+func TestAccSentryProject_removeDefaultRuleOnCreate(t *testing.T) {
+	teamName := acctest.RandomWithPrefix("tf-team")
+	projectName := acctest.RandomWithPrefix("tf-project")
+	rn := "sentry_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSentryProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryProjectConfigComplex(teamName, projectName, false, true),
+				Check:  testAccSentryRuleRemoved(rn),
+			},
+		},
+	})
+}
+
 func TestAccSentryProject_changeTeam(t *testing.T) {
 	teamName1 := acctest.RandomWithPrefix("tf-team")
 	teamName2 := acctest.RandomWithPrefix("tf-team")


### PR DESCRIPTION
Add back removing default rule and key logic

Passes all tests except data source issue alert which also fails in the upstream repo

Passed manual testing here: https://github.com/Canva/infrastructure/pull/48268, created project without default key and rules: https://sentry.io/settings/canva/projects/zander-test-rpc/keys/
