### PR TITLE
Updated metric alert to include integration id for slack action

### DIFF
--- a/docs/data-sources/metric_alert.md
+++ b/docs/data-sources/metric_alert.md
@@ -42,6 +42,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 
@@ -99,6 +100,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `integration_id` (Number)
 - `target_identifier` (String)
 - `target_type` (String)
 - `type` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -270,6 +270,12 @@ output "issue_alert_url" {
 # Metric alert
 #
 
+data "sentry_organization_integration" "slack" {
+  organization = "organization"
+  provider_key = "slack"
+  name         = "organization-slack"
+}
+
 resource "sentry_metric_alert" "main" {
   organization      = sentry_project.main.organization
   project           = sentry_project.main.id
@@ -286,6 +292,18 @@ resource "sentry_metric_alert" "main" {
       type              = "email"
       target_type       = "team"
       target_identifier = sentry_team.main.team_id
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300
     label           = "critical"

--- a/docs/index.md
+++ b/docs/index.md
@@ -273,7 +273,7 @@ output "issue_alert_url" {
 data "sentry_organization_integration" "slack" {
   organization = "organization"
   provider_key = "slack"
-  name         = "organization-slack"
+  name         = "Organization" // corresponds to Slack's name of your organisation
 }
 
 resource "sentry_metric_alert" "main" {

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -13,6 +13,12 @@ Sentry Metric Alert resource.
 ## Example Usage
 
 ```terraform
+data "sentry_organization_integration" "slack" {
+  organization = "organization"
+  provider_key = "slack"
+  name         = "organization-slack"
+}
+
 resource "sentry_metric_alert" "main" {
   organization      = sentry_project.main.organization
   project           = sentry_project.main.id
@@ -30,6 +36,18 @@ resource "sentry_metric_alert" "main" {
       type              = "email"
       target_type       = "team"
       target_identifier = sentry_team.main.team_id
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = data.sentry_organization_integration.slack.internal_id
     }
     alert_threshold = 300
     label           = "critical"
@@ -98,6 +116,10 @@ Required:
 - `target_identifier` (String)
 - `target_type` (String)
 - `type` (String)
+
+Optional:
+
+- `integration_id` (Number)
 
 Read-Only:
 

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -47,7 +47,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
-      integration_id    = data.sentry_organization_integration.slack.internal_id
+      integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300
     label           = "critical"

--- a/examples/data-sources/sentry_metric_alert/data-source.tf
+++ b/examples/data-sources/sentry_metric_alert/data-source.tf
@@ -27,6 +27,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canva/terraform-provider-sentry
 
 go 1.18
 
-replace github.com/jianyuan/go-sentry/v2 => github.com/canva/go-sentry v1.4.1
+replace github.com/jianyuan/go-sentry/v2 => github.com/canva/go-sentry v1.4.2
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/canva/go-sentry v1.4.1 h1:ZkIN9jHxekFItfYcEMtUK4I5HpqsEZb0PdhTMAZp1B8=
-github.com/canva/go-sentry v1.4.1/go.mod h1:B2sP4gGg/R6gdfVr9RtZ/9R7L0gFGKieOfAAjlDyqiA=
+github.com/canva/go-sentry v1.4.2 h1:rdtVl5qRFo09cn5OvmHK9lFoqSrg6TZ1A2dsmCNS3HA=
+github.com/canva/go-sentry v1.4.2/go.mod h1:B2sP4gGg/R6gdfVr9RtZ/9R7L0gFGKieOfAAjlDyqiA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/sentry/data_source_sentry_metric_alert.go
+++ b/sentry/data_source_sentry_metric_alert.go
@@ -107,6 +107,10 @@ func dataSourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -118,6 +118,10 @@ func resourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -340,6 +344,9 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.ID = sentry.String(v)
 			}
 		}
+		if v, _ := actionMap["integration_id"].(int); v != 0 {
+			action.IntegrationID = sentry.Int(v)
+		}
 		actions = append(actions, action)
 	}
 	return actions
@@ -376,8 +383,13 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["type"] = action.Type
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
+		if action.IntegrationID != nil {
+			actionMap["integration_id"] = action.IntegrationID
+		}
+
 		actionList = append(actionList, actionMap)
 	}
+
 	return actionList
 }
 

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -383,9 +383,7 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["type"] = action.Type
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
-		if action.IntegrationID != nil {
-			actionMap["integration_id"] = action.IntegrationID
-		}
+		actionMap["integration_id"] = action.IntegrationID
 
 		actionList = append(actionList, actionMap)
 	}

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -344,7 +344,7 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.ID = sentry.String(v)
 			}
 		}
-		if v, _ := actionMap["integration_id"].(int); v != 0 {
+		if v, ok := actionMap["integration_id"].(int); ok && v != 0 {
 			action.IntegrationID = sentry.Int(v)
 		}
 		actions = append(actions, action)

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -132,7 +132,7 @@ resource "sentry_metric_alert" "test" {
 			type              = "email"
 			target_type       = "team"
 			target_identifier = sentry_team.test.internal_id
-            integration_id    = 32
+			integration_id    = 32
 		}
 
 		alert_threshold   = 1000

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -132,6 +132,7 @@ resource "sentry_metric_alert" "test" {
 			type              = "email"
 			target_type       = "team"
 			target_identifier = sentry_team.test.internal_id
+            integration_id    = 32
 		}
 
 		alert_threshold   = 1000


### PR DESCRIPTION
See PR to upstream here: https://github.com/jianyuan/terraform-provider-sentry/pull/217

# Intent

We need to add an `integration_id` field to the metric alert action in order to specify the Slack Integration (in order to send alerts to Slack).

This is seen in the below example:

```tf
data "sentry_organization_integration" "slack" {
  organization = "organization"
  provider_key = "slack"
  name         = "Organization" // corresponds to Slack's name of your organisation
}

resource "sentry_metric_alert" "main" {
  // ...
  trigger {
    action {
      type              = "slack"
      target_type       = "specific"
      target_identifier = "#slack-channel"
      integration_id    = data.sentry_organization_integration.slack.id // <---- New addition
    }
    // ...
  }
```