### PR TITLE
Add slack channel option when creating a metric alert action

### DIFF
--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -119,10 +119,13 @@ Required:
 
 Optional:
 
+- `input_channel_id` (String) A slack channel ID to be used when the type is set to 'slack'
 - `integration_id` (Number)
 
 Read-Only:
 
+- `alert_rule_trigger_id` (String)
+- `description` (String)
 - `id` (String) The ID of this resource.
 
 ## Import


### PR DESCRIPTION
# Intent

To add the `input_channel_id` option when creating a metric alert action. Without adding in a channel option (and only providing a channel name), Sentry performs the following on action creation:
1. Create the action with ID1
2. Ask Slack for the channel ID using ID11 
3. Reset the action with ID2 

By reseting the action with a new ID (ID2), terraform loses reference to the "true" state of Sentry and errors out with:
`root resource was present but now absent` on terraform apply.