### PR TITLE
[EDGE-766] Prevent issue alert UUID being outputted

### DIFF
--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -219,6 +219,7 @@ func (r *IssueAlertResource) Create(ctx context.Context, req resource.CreateRequ
 		data.Project.ValueString(),
 		params,
 	)
+	
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error creating issue alert: %s", err.Error()))
 		return
@@ -251,6 +252,10 @@ func (r *IssueAlertResource) Read(ctx context.Context, req resource.ReadRequest,
 		data.Project.ValueString(),
 		data.Id.ValueString(),
 	)
+	// Remove task UUID as it's not needed, otherwise it will end up in the JSON output and cause
+	// 'Provider caused inconsistent result after apply' errors.
+	action.TaskUUID = nil
+
 	if apiResp.StatusCode == http.StatusNotFound {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Issue alert not found: %s", err.Error()))
 		resp.State.RemoveResource(ctx)
@@ -308,6 +313,10 @@ func (r *IssueAlertResource) Update(ctx context.Context, req resource.UpdateRequ
 		data.Id.ValueString(),
 		params,
 	)
+	// Remove task UUID as it's not needed, otherwise it will end up in the JSON output and cause
+	// 'Provider caused inconsistent result after apply' errors.
+	action.TaskUUID = nil
+
 	if apiResp.StatusCode == http.StatusNotFound {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Notification Action not found: %s", err.Error()))
 		resp.State.RemoveResource(ctx)


### PR DESCRIPTION
## Context

Basically same as https://github.com/Canva/go-sentry/pull/8 but implementing this in the TF provider instead.

`uuid` field is causing permanent TF drift, failures to apply and is not required in the alert output.

Example: https://buildkite.com/canva-org/infra-apply-terraform/builds/170168

```
  # module.sentry_high_frequency_alert[0].sentry_issue_alert.default will be updated in-place
  ~ resource "sentry_issue_alert" "default" {
      ~ actions      = jsonencode(
          ~ [
              ~ {
                  ~ channel    = "edge-notifications" -> "#edge-notifications"
                    id         = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
                  ~ name       = "Send a notification to the Canva Slack workspace to edge-notifications (optionally, an ID: C021PEQFXGV) and show tags [] and notes  in notification" -> "Send a notification to the Canva Slack workspace to #edge-notifications (optionally, an ID: C021PEQFXGV) and show tags [] and notes  in notification"
                    tags       = ""
                  - uuid       = "7e1fecf2-bd58-4a8b-990c-c28a61bba5e9" -> null
                    # (3 unchanged elements hidden)
                },
            ]
        )
        id           = "14511763"
        name         = "High frequency of events(+500) in prod)"
        # (7 unchanged attributes hidden)
    }
```

Failure to apply:

```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to
│ module.sentry_high_frequency_alert[0].sentry_issue_alert.default, provider
│ "provider[\"canva.com/infrastructure/sentry\"]" produced an unexpected new
│ value: .actions: was
│ cty.StringVal("[{\"channel\":\"#edge-notifications\",\"channel_id\":\"C021PEQFXGV\",\"id\":\"sentry.integrations.slack.notify_action.SlackNotifyServiceAction\",\"label\":\"Send
│ a slack notification\",\"name\":\"Send a notification to the Canva Slack
│ workspace to #edge-notifications (optionally, an ID: C021PEQFXGV) and show
│ tags [] and notes  in
│ notification\",\"tags\":\"\",\"workspace\":\"23762\"}]"), but now
│ cty.StringVal("[{\"channel\":\"edge-notifications\",\"channel_id\":\"C021PEQFXGV\",\"id\":\"sentry.integrations.slack.notify_action.SlackNotifyServiceAction\",\"label\":\"Send
│ a slack notification\",\"name\":\"Send a notification to the Canva Slack
│ workspace to edge-notifications (optionally, an ID: C021PEQFXGV) and show
│ tags [] and notes  in
│ notification\",\"tags\":\"\",\"uuid\":\"7e1fecf2-bd58-4a8b-990c-c28a61bba5e9\",\"workspace\":\"23762\"}]").
│
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

## Intent

Remove the UUID field from Sentry issue alerts.